### PR TITLE
Fix CI tests

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -12,8 +12,8 @@ else
 	test=""
 fi
 
-in=hexend_veth1
-out=hexend_veth2
+in=veth1
+out=veth2
 curr_test="none"
 failed=0
 
@@ -21,6 +21,8 @@ setup() {
 	ip link add dev $in type veth peer name $out
 	ip link set dev $in up
 	ip link set dev $out up
+	# Allow interfaces to come up
+	sleep 3
 }
 
 teardown() {


### PR DESCRIPTION
For some reason the CI did not like the veth names hexend_vethX

Also added sleep to allow time to bring up interfaces (could potentially cause problems).